### PR TITLE
Include all components when dehydrating the form

### DIFF
--- a/src/Components/Concerns/HasChildComponents.php
+++ b/src/Components/Concerns/HasChildComponents.php
@@ -46,6 +46,6 @@ trait HasChildComponents
 
     public function hasChildComponentContainer(): bool
     {
-        return ! $this->isHidden() && $this->getChildComponents() !== [];
+        return $this->getChildComponents() !== [];
     }
 }

--- a/src/Concerns/HasState.php
+++ b/src/Concerns/HasState.php
@@ -65,11 +65,7 @@ trait HasState
     {
         $this->callBeforeStateDehydrated();
 
-        foreach ($this->getComponents() as $component) {
-            if ($component->isHidden()) {
-                continue;
-            }
-
+        foreach ($this->getComponents(withHidden: true) as $component) {
             $componentStatePath = $component->getStatePath();
 
             if ($component->isDehydrated()) {
@@ -78,10 +74,6 @@ trait HasState
                 }
 
                 foreach ($component->getChildComponentContainers() as $container) {
-                    if ($container->isHidden()) {
-                        continue;
-                    }
-
                     $container->dehydrateState($state);
                 }
             } else {


### PR DESCRIPTION
Like before, only "visible" fields will be validated, but now all fields are returned from `getState()`. 