### PR TITLE
Allow to trigger delete events on child relations Fixes issue #1527

### DIFF
--- a/src/Components/RelationshipRepeater.php
+++ b/src/Components/RelationshipRepeater.php
@@ -46,7 +46,9 @@ class RelationshipRepeater extends Repeater
                 $recordsToDelete[] = $keyToCheckForDeletion;
             }
 
-            $relationship->whereIn($localKeyName, $recordsToDelete)->delete();
+            $relationship->whereIn($localKeyName, $recordsToDelete)->get()->each(function ($record) {
+                $record->delete();
+            });
 
             $childComponentContainers = $component->getChildComponentContainers();
 


### PR DESCRIPTION
Allow to trigger delete events when deleting child relations via the RelationshipRepeater